### PR TITLE
Added base version for ghc 8.8

### DIFF
--- a/timer-wheel.cabal
+++ b/timer-wheel.cabal
@@ -44,7 +44,7 @@ source-repository head
 library
   build-depends:
     atomic-primops ^>= 0.8,
-    base ^>= 4.9 || ^>= 4.10 || ^>= 4.11 || ^>= 4.12,
+    base ^>= 4.9 || ^>= 4.10 || ^>= 4.11 || ^>= 4.12 || ^>= 4.13,
     psqueues ^>= 0.2.7,
     vector ^>= 0.10 || ^>= 0.11 || ^>= 0.12
   if !impl(ghc >= 8.4)


### PR DESCRIPTION
Hi,

I just added a version for base so that timer-wheel compiles with ghc 8.8.x and does work with stackage LTS-15.1. 
It's only a small change but I don't know if you intend other changes as well. 

Best wishes,
Michael